### PR TITLE
Add deprecation message

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -1,3 +1,5 @@
+Status: This explainer has been deprecated in favor of the [Segments Property Explainer](https://github.com/WICG/visual-viewport/blob/gh-pages/segments-explainer/SEGMENTS-EXPLAINER.md) under the Visual Viewport API spec.
+
 # Window Segments Enumeration API
 
 [Daniel Libby](https://github.com/dlibby-), [Zouhir Chahoud](https://github.com/Zouhir)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Window Segments Enumeration API
 
+Status: This explainer has been deprecated in favor of the [Segments Property Explainer](https://github.com/WICG/visual-viewport/blob/gh-pages/segments-explainer/SEGMENTS-EXPLAINER.md) under the Visual Viewport API spec.
+
+---
+
 This repository proposes a JavaScript API that will help web developers effectively lay content out in a browser window that spans multiple displays or across the fold on foldable devices by providing the geometry of the available display regions.
 
 The [EXPLAINER.md](/EXPLAINER.md) file highlights the motivation and the proposed API's syntax. Please take a look and if you have any feedback, thoughts or comments we'd love to hear them and opening an issue on this repo is a great start.


### PR DESCRIPTION
The Windows Enumeration API has been deprecated in favor of the Segments Property that hangs off the Visual Viewport API. I've added deprecation messages to the README and the Explainer and links to the new explainer under the Visual Viewport API page.